### PR TITLE
Idea: Use Webdriver instead of Phantom

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,7 +1,7 @@
 var mockup = require('./index');
 
 mockup.create({
-  url: 'https://flinc.org',
-  template: 'flat_responsive', // available: 'flat_responsive', 'flat_responsive_2'
+  url: 'https://google.com',
+  template: 'flat_responsive_2', // available: 'flat_responsive', 'flat_responsive_2'
   output: 'responsive_mockup.png'
 });

--- a/index.js
+++ b/index.js
@@ -1,56 +1,58 @@
-var webpage = require('webpage');
+var easyimg = require('easyimage');
+var webdriverio = require('webdriverio');
 
 function takeScreenshot(url, screenshotsDir, layer, done) {
-  var page = webpage.create();
+
+  layer.client = layer.client || { desiredCapabilities: {browserName: 'phantomjs'}};
+
+  var client = webdriverio.remote(layer.client).init();
+
+  if (layer.client.desiredCapabilities && layer.client.desiredCapabilities.chromeOptions && layer.client.desiredCapabilities.chromeOptions.mobileEmulation) {
+    // Can't set dimensions when mobileEmulation is set
+  } else {
+    client.setViewportSize({
+      width: layer.viewport.width,
+      height: layer.viewport.height
+    });
+  }
 
   var output = screenshotsDir + '/' + layer.type + '.png';
 
-  page.viewportSize = { width: layer.viewport.width, height: layer.viewport.height };
-  page.clipRect = { top: 0, left: 0, width: page.viewportSize.width, height: page.viewportSize.height };
-
   console.info('Now loading: layer '  + layer.type + '...');
 
-  page.open(url, function(status) {
-    if (status !== 'success') console.error('Unable to load the address for layer ' + layer.type);
-
-    window.setTimeout(function() {
+  client.url(url)
+    .pause(5000) // TODO: Find better way to ensure page is loaded
+    .saveScreenshot(output, function () {
       console.info('Generated: ' + output);
-      page.render(output);
+      easyimg.crop({ // Because Chrome is rendering even whitespace around mobile emulator
+        src: output, dst: output, x: 0, y: 0, gravity: 'NorthWest',
+        cropwidth: layer.viewport.width, cropheight: layer.viewport.height
+      });
       done();
-    }, 1000);
+      //client.end(); // Not sure about this
+    });
 
-  });
 }
 
 function renderMockup(path, output, metadata) {
-  var page = webpage.create();
 
-  page.viewportSize = {
+  var client = webdriverio.remote({
+    desiredCapabilities: {browserName: 'phantomjs'}
+  }).init();
+
+  client.setViewportSize({
     width: metadata.mockup.width,
     height: metadata.mockup.height
-  };
-
-  page.clipRect = {
-    top: 0,
-    left: 0,
-    width: metadata.mockup.width,
-    height: metadata.mockup.height
-  };
-
-  page.open(path, function(status) {
-    if (status !== 'success') console.error('Unable to load mockup!');
-
-    page.onConsoleMessage = function(msg) {
-      console.warn('[render] ' + msg);
-    };
-
-    window.setTimeout(function() {
-      console.info('Saved responsive mockup to: ' + output);
-      page.render(output);
-      phantom.exit();
-    }, 500);
-
   });
+
+  client.url(path)
+    .pause(1000)
+    .saveScreenshot(output, function () {
+      console.info('Saved responsive mockup to: ' + output);
+      client.end(function () {
+        console.info("Done");
+      });
+    });
 }
 
 function create(options) {
@@ -77,9 +79,9 @@ function create(options) {
     }
   }
 
-  metadata.layers.forEach(function(layer) {
-    tasks.push(function() { takeScreenshot(url, screenshotsDir, layer, next); });
-  });
+  //metadata.layers.forEach(function(layer) {
+  //  tasks.push(function() { takeScreenshot(url, screenshotsDir, layer, next); });
+  //});
 
   tasks.push(function() { renderMockup(mockupPath, output, metadata); });
 

--- a/index.js
+++ b/index.js
@@ -79,9 +79,9 @@ function create(options) {
     }
   }
 
-  //metadata.layers.forEach(function(layer) {
-  //  tasks.push(function() { takeScreenshot(url, screenshotsDir, layer, next); });
-  //});
+  metadata.layers.forEach(function(layer) {
+    tasks.push(function() { takeScreenshot(url, screenshotsDir, layer, next); });
+  });
 
   tasks.push(function() { renderMockup(mockupPath, output, metadata); });
 

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "description": "Takes screenshots of a webpage in different resolutions and automatically applies it to mockups.",
   "main": "index.js",
   "author": "Christian Bäuerlein",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "easyimage": "^1.2.2",
+    "webdriverio": "^2.4.5"
+  }
 }

--- a/templates/flat_responsive_2/metadata.js
+++ b/templates/flat_responsive_2/metadata.js
@@ -7,6 +7,18 @@
     layers: [
       {
         type: 'mobile',
+        client: {
+          host: "localhost",
+          port: 9515,
+          desiredCapabilities: {
+            browserName: 'chrome',
+            chromeOptions: {
+              mobileEmulation: {
+                deviceName: 'Apple iPhone 5'
+              }
+            }
+          }
+        },
         topLeft: {
           x: 445,
           y: 599
@@ -22,6 +34,11 @@
       },
       {
         type: 'tablet',
+        client: {
+          host: "localhost",
+          port: 9515,
+          desiredCapabilities: { browserName: 'chrome' }
+        },
         topLeft: {
           x: 158,
           y: 407
@@ -37,6 +54,11 @@
       },
       {
         type: 'desktop',
+        client: {
+          host: "localhost",
+          port: 9515,
+          desiredCapabilities: { browserName: 'chrome' }
+        },
         topLeft: {
           x: 238,
           y: 222


### PR DESCRIPTION
Hi there, I really like this project...

I needed to use Chrome instead of PhantomJS, as it renders a page a lot differently (even when using PhantomJS 2), so I swapped Phantom to neutral Webdriver which can communicate with any browser - Chrome, Firefox and even PhantomJS – but I can make a choice :)

I'm really not happy with my code, but I'm really not good with browser automation. But it's doing what it should do, so I'm making this PR not with intent to merge it, but to discuss it or maybe somebody can help me with a correct implementation.

Biggest ugliness is IMHO dep on easyimage, as Chrome is not able to resize below 400px (https://code.google.com/p/chromium/issues/detail?id=275686), only with use of mobileEmulation, which causes screenshots to contain crazy amount of whitespace.

![mobile](https://cloud.githubusercontent.com/assets/697301/6402361/46fc36a8-be07-11e4-9a46-a981bcdf708e.png)
