### PR TITLE
Switches headless browser from PhantomJS to Nightmare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+node_modules/*
 screenshots/*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Responsive Mockups via PhantomJS 2.0
 
-Small PhantomJS based script that allows you to automatically create mockup graphics, providing only a URL.
+Small Nightmare.js/Electron based script that allows you to automatically create mockup graphics, providing only a URL.
 
 ![mockup 1](https://i.imgur.com/IUEHBcI.png)
 ![mockup 2](https://i.imgur.com/kolyLwL.png)
@@ -8,28 +8,12 @@ Small PhantomJS based script that allows you to automatically create mockup grap
 
 ## How To
 
+* Make sure you have a current node version installed (which supports generators using the harmony flag)
 * Clone this repo
+* `npm install` all dependencies
 * Edit `example.js` to choose mockup template and target url
-* Call `phantomjs example.js` (for an example with a single URL)
-* Or call `phantomjs example-mobile-multiple.js` (for an example with multiple URLs)
-
-## Requirements
-
-The only external requirement is PhantomJS in version >= 2.0.0.
-
-`brew install phantomjs`
-
-Double check the version of PhantomJS
-
-`phantomjs -v`
-
-## Known issues with SSL
-
-PhantomJS seems to have problems with some SSL certficates. In case you get errors like `Unable to load the address for layer [...]` - you can get a more verbose output by running PhantomJS in debug mode, e.g. `phantomjs --debug=true example.js`.
-
-If the output says something like `SSL Error: "The issuer certificate of a locally looked up certificate could not be found"`, but you still want to take screenshots via HTTPS, you can deactivate SSL checks using `phantomjs --ignore-ssl-errors=true example.js`.
-
-Please be aware that this disables SSL certificate validations, so don't pass credentials or other data to the script that would require a verified secure connection.
+* Call `node --harmony example.js` (for an example with a single URL)
+* Or call `node --harmony example-mobile-multiple.js` (for an example with multiple URLs)
 
 ## Credits for provided mockup templates
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Small Nightmare.js/Electron based script that allows you to automatically create
 
 ## How To
 
-* Make sure you have a current node version installed (which supports generators using the harmony flag)
+* Make sure you have a current node version installed
 * Clone this repo
 * `npm install` all dependencies
 * Edit `example.js` to choose mockup template and target url
-* Call `node --harmony example.js` (for an example with a single URL)
-* Or call `node --harmony example-mobile-multiple.js` (for an example with multiple URLs)
+* Call `node example.js` (for an example with a single URL)
+* Or call `node example-mobile-multiple.js` (for an example with multiple URLs)
 
 ## Credits for provided mockup templates
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "license": "MIT",
   "dependencies": {
     "mkdirp": "^0.5.1",
-    "nightmare": "^2.1.1",
-    "vo": "^1.0.3"
+    "nightmare": "^2.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,13 @@
 {
   "name": "responsive_mockups",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Takes screenshots of a webpage in different resolutions and automatically applies it to mockups.",
   "main": "index.js",
   "author": "Christian Bäuerlein",
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "mkdirp": "^0.5.1",
+    "nightmare": "^2.1.1",
+    "vo": "^1.0.3"
+  }
 }


### PR DESCRIPTION
I'm thinking about switching the headless browser lib from PhantomJS to Nightmare.

There are some Pros and Cons:

Pro:
- Nightmare uses Electron, which has much better support for new browser features, e.g. WebGL (we could render screenshots in much more interesting ways).
- PhantomJS still is buggy sometimes, e.g. when setting the viewport.
- I've never encountered any SSL Problems with Nightmare, with PhantomJS very often (see readme).
- I hope for better cross platform compatibility.

Con:
- More dependencies, need to do an `npm install`
- ~~Nightmare docs are as bad as the PhantomJS docs. :(~~ (got help in the GH issues)
- ~~Still need to figure out, how to make better use of the ES generators feature in this project.~~

Feedback is very welcome!

Best,

Christian
